### PR TITLE
Add CI builds graph

### DIFF
--- a/gitlab_builds
+++ b/gitlab_builds
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from lib import get_gitlab_instance
+
+import sys
+
+SHOW_CONFIG = len(sys.argv) >= 2 and sys.argv[1] == 'config'
+
+if SHOW_CONFIG:
+    print('graph_title GitLab CI builds')
+    print('graph_vlabel builds')
+    print('graph_args -l 0')
+    print('graph_category gitlab')
+
+gitlab = get_gitlab_instance()
+db = gitlab.get_db_connection()
+try:
+    cursor = db.cursor()
+    cursor.execute(
+        'SELECT status, COUNT(status) AS amount '
+        'FROM ci_builds '
+        'GROUP BY status'
+    )
+    for row in cursor.fetchall():
+        if SHOW_CONFIG:
+            print('{0}.draw AREASTACK'.format(*row))
+            print('{0}.label {0}'.format(*row))
+        else:
+            print('{0}.value {1:d}'.format(*row))
+
+    cursor.close()
+finally:
+    db.close()

--- a/gitlab_builds
+++ b/gitlab_builds
@@ -3,6 +3,13 @@ from lib import get_gitlab_instance
 
 import sys
 
+
+# Use gitlab-ci colours
+COLOR_MAPPING = {
+    'success': '26AB5D',
+    'failure': 'E82757',
+    'canceled': '7E8FA5',
+}
 SHOW_CONFIG = len(sys.argv) >= 2 and sys.argv[1] == 'config'
 
 if SHOW_CONFIG:
@@ -24,6 +31,9 @@ try:
         if SHOW_CONFIG:
             print('{0}.draw AREASTACK'.format(*row))
             print('{0}.label {0}'.format(*row))
+            print('{0}.color {color:s}'.format(
+                *row, color=COLOR_MAPPING.get(row[0], '000000')
+            ))
         else:
             print('{0}.value {1:d}'.format(*row))
 

--- a/gitlab_builds
+++ b/gitlab_builds
@@ -25,7 +25,8 @@ try:
     cursor.execute(
         'SELECT status, COUNT(status) AS amount '
         'FROM ci_builds '
-        'GROUP BY status'
+        'GROUP BY status '
+        'ORDER BY status DESC'
     )
     for row in cursor.fetchall():
         if SHOW_CONFIG:

--- a/gitlab_builds
+++ b/gitlab_builds
@@ -21,7 +21,7 @@ if SHOW_CONFIG:
     print('graph_category gitlab')
     print('graph_order {0}'.format(' '.join(sorted(BUILD_STATES.keys()))))
     for build_state in BUILD_STATES:
-        print('{0}.min 0\n{0}.draw AREA\n{0}.type DERIVE\n{0}.label {0}\n{0}.colour {1}'  # noqa
+        print('{0}.min 0\n{0}.draw AREASTACK\n{0}.type DERIVE\n{0}.label {0}\n{0}.colour {1}'  # noqa
               .format(build_state, BUILD_STATES[build_state]))
 else:
     gitlab = get_gitlab_instance()

--- a/gitlab_builds
+++ b/gitlab_builds
@@ -7,7 +7,7 @@ import sys
 # Use gitlab-ci colours
 COLOUR_MAPPING = {
     'success': '26AB5D',
-    'failure': 'E82757',
+    'failed': 'E82757',
     'canceled': '7E8FA5',
 }
 SHOW_CONFIG = len(sys.argv) >= 2 and sys.argv[1] == 'config'

--- a/gitlab_builds
+++ b/gitlab_builds
@@ -5,7 +5,7 @@ import sys
 
 
 # Use gitlab-ci colours
-COLOR_MAPPING = {
+COLOUR_MAPPING = {
     'success': '26AB5D',
     'failure': 'E82757',
     'canceled': '7E8FA5',
@@ -31,8 +31,8 @@ try:
         if SHOW_CONFIG:
             print('{0}.draw AREASTACK'.format(*row))
             print('{0}.label {0}'.format(*row))
-            print('{0}.color {color:s}'.format(
-                *row, color=COLOR_MAPPING.get(row[0], '000000')
+            print('{0}.colour {colour:s}'.format(
+                *row, colour=COLOUR_MAPPING.get(row[0], '000000')
             ))
         else:
             print('{0}.value {1:d}'.format(*row))

--- a/gitlab_builds
+++ b/gitlab_builds
@@ -5,39 +5,44 @@ import sys
 
 
 # Use gitlab-ci colours
-COLOUR_MAPPING = {
+BUILD_STATES = {
     'success': '26AB5D',
     'failed': 'E82757',
     'canceled': '7E8FA5',
+    'pending': 'E95D39',
+    'running': 'FF8000',
 }
 SHOW_CONFIG = len(sys.argv) >= 2 and sys.argv[1] == 'config'
 
 if SHOW_CONFIG:
     print('graph_title GitLab CI builds')
-    print('graph_vlabel builds')
+    print('graph_vlabel builds per ${graph_period}')
     print('graph_args -l 0')
     print('graph_category gitlab')
+    print('graph_order {0}'.format(' '.join(sorted(BUILD_STATES.keys()))))
+    for build_state in BUILD_STATES:
+        print('{0}.min 0\n{0}.draw AREA\n{0}.type DERIVE\n{0}.label {0}\n{0}.colour {1}'  # noqa
+              .format(build_state, BUILD_STATES[build_state]))
+else:
+    gitlab = get_gitlab_instance()
+    db = gitlab.get_db_connection()
 
-gitlab = get_gitlab_instance()
-db = gitlab.get_db_connection()
-try:
-    cursor = db.cursor()
-    cursor.execute(
-        'SELECT status, COUNT(status) AS amount '
-        'FROM ci_builds '
-        'GROUP BY status '
-        'ORDER BY status DESC'
-    )
-    for row in cursor.fetchall():
-        if SHOW_CONFIG:
-            print('{0}.draw AREASTACK'.format(*row))
-            print('{0}.label {0}'.format(*row))
-            print('{0}.colour {colour:s}'.format(
-                *row, colour=COLOUR_MAPPING.get(row[0], '000000')
-            ))
-        else:
-            print('{0}.value {1:d}'.format(*row))
+    # python <2.7 compat, no {build_state: 0 for build_state in BUILD_STATES}
+    states = dict([(build_state, 0) for build_state in BUILD_STATES])
+    try:
+        cursor = db.cursor()
+        cursor.execute(
+            'SELECT status, COUNT(status) AS amount '
+            'FROM ci_builds '
+            'GROUP BY status '
+            'ORDER BY status DESC'
+        )
+        for state, value in cursor.fetchall():
+            states.update({state: value})
 
-    cursor.close()
-finally:
-    db.close()
+        cursor.close()
+    finally:
+        db.close()
+
+    for build_state, build_amount in states.items():
+        print('{0}.value {1:d}'.format(build_state, build_amount))


### PR DESCRIPTION
Uses gitlab internal colour definition to display builds in gitlab-ci. Maybe we want to change this in future to a %-graph, but for now i'll leave it as-is.

We should consider refactoring the instance-initialization to avoid repeating ourself in plugin code.