### PR TITLE
Add shared dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ user git
 [gitlab_redis_*]
 user gitlab-redis
 #env.redis_socket /var/opt/gitlab/redis/redis.socket  # optional, defaults to GitLab omnibus redis instance
+
+[gitlab_total_registry_size]
+user registry
 ```
 2. Change your directory to ```/etc/munin/plugins```. Create symlinks for each plugin (```ln -s```) which you want to
 activate. Please take a look at the plugin specific documentation.

--- a/gitlab_total_artifacts_size
+++ b/gitlab_total_artifacts_size
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from lib import dirsize
+from lib import get_gitlab_instance
+import sys
+
+
+gitlab = get_gitlab_instance()
+artifacts_root = gitlab.get_artifacts_dir()
+
+if len(sys.argv) >= 2 and sys.argv[1] == 'config':
+    print('graph_title GitLab build artifacts disk usage')
+    print('graph_vlabel build artifacts disk usage')
+    print('graph_args -l 0 --base 1024')
+    print('graph_category gitlab')
+    print('artifacts_size.label build artifacts')
+    print('artifacts_size.draw AREA')
+    sys.exit(0)
+
+artifacts_size = 0
+
+try:
+    artifacts_size = dirsize(artifacts_root)
+except OSError as e:
+    print(e)
+    sys.exit(1)
+
+print('artifacts_size.value ' + str(artifacts_size))

--- a/gitlab_total_cache_size
+++ b/gitlab_total_cache_size
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from lib import dirsize
+from lib import get_gitlab_instance
+import sys
+
+
+gitlab = get_gitlab_instance()
+cache_root = gitlab.get_cache_dir()
+
+if len(sys.argv) >= 2 and sys.argv[1] == 'config':
+    print('graph_title GitLab build cache disk usage')
+    print('graph_vlabel build cache disk usage')
+    print('graph_args -l 0 --base 1024')
+    print('graph_category gitlab')
+    print('cache_size.label build cache')
+    print('cache_size.draw AREA')
+    sys.exit(0)
+
+cache_size = 0
+
+try:
+    cache_size = dirsize(cache_root)
+except OSError as e:
+    print(e)
+    sys.exit(1)
+
+print('cache_size.value ' + str(cache_size))

--- a/gitlab_total_registry_size
+++ b/gitlab_total_registry_size
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+from lib import dirsize
+from lib import get_gitlab_instance
+import sys
+
+
+gitlab = get_gitlab_instance()
+registry_root = gitlab.get_registry_dir()
+
+if len(sys.argv) >= 2 and sys.argv[1] == 'config':
+    print('graph_title GitLab docker registry disk usage')
+    print('graph_vlabel docker registry disk usage')
+    print('graph_args -l 0 --base 1024')
+    print('graph_category gitlab')
+    print('registry_size.label docker registry')
+    print('registry_size.draw AREA')
+    sys.exit(0)
+
+registry_size = 0
+
+try:
+    registry_size = dirsize(registry_root)
+except OSError as e:
+    print(e)
+    sys.exit(1)
+
+print('registry_size.value ' + str(registry_size))

--- a/lib/gitlab.py
+++ b/lib/gitlab.py
@@ -18,6 +18,9 @@ class GitLabInstance(object):
     def get_artifacts_dir(self):
         return os.path.join(self.shared_dir, 'artifacts')
 
+    def get_cache_dir(self):
+        return os.path.join(self.shared_dir, 'cache')
+
     def get_repository_dir(self):
         return os.path.join(self.get_data_dir(), 'repositories')
 

--- a/lib/gitlab.py
+++ b/lib/gitlab.py
@@ -21,6 +21,9 @@ class GitLabInstance(object):
     def get_cache_dir(self):
         return os.path.join(self.shared_dir, 'cache')
 
+    def get_registry_dir(self):
+        return os.path.join(self.shared_dir, 'registry')
+
     def get_repository_dir(self):
         return os.path.join(self.get_data_dir(), 'repositories')
 

--- a/lib/gitlab.py
+++ b/lib/gitlab.py
@@ -11,6 +11,13 @@ class GitLabInstance(object):
     def get_data_dir(self):
         return os.path.join(self.gitlab_dir, 'git-data')
 
+    @property
+    def shared_dir(self):
+        return os.path.join(self.gitlab_dir, 'gitlab-rails', 'shared')
+
+    def get_artifacts_dir(self):
+        return os.path.join(self.shared_dir, 'artifacts')
+
     def get_repository_dir(self):
         return os.path.join(self.get_data_dir(), 'repositories')
 


### PR DESCRIPTION
With new GitLab 8.8 more directory sizes get important, because you may have to plug in more diskspace on heavy CI-build cache/artifacts or docker container registry usage:
- Build artifacts
- Build caches
- Docker container registry

Important is to set the correct user for docker registry size retrieval.