### PR TITLE
Consider reopened issues as opened

### DIFF
--- a/gitlab_total_issues_open
+++ b/gitlab_total_issues_open
@@ -16,7 +16,7 @@ if len(sys.argv) >= 2 and sys.argv[1] == 'config':
 gitlab = get_gitlab_instance()
 db = gitlab.get_db_connection()
 cursor = db.cursor()
-cursor.execute("SELECT COUNT(*) FROM issues WHERE state = 'opened'")
+cursor.execute("SELECT COUNT(*) FROM issues WHERE state IN ('opened', 'reopened')")
 count = cursor.fetchone()[0]
 cursor.close()
 db.close()


### PR DESCRIPTION
We should consider reopened issues as same as opened ones in `gitlab_total_issues_open`.

Closes #10 