### PR TITLE
State column in issues and merge_requests is deprecated.

### DIFF
--- a/gitlab_total_issues_open
+++ b/gitlab_total_issues_open
@@ -21,12 +21,12 @@ gitlab = get_gitlab_instance()
 db = gitlab.get_db_connection()
 
 cursor = db.cursor()
-cursor.execute("SELECT COUNT(*) FROM issues i LEFT JOIN issue_assignees ia ON i.id = ia.issue_id WHERE i.state IN ('opened', 'reopened') AND ia.user_id IS NULL")
+cursor.execute("SELECT COUNT(*) FROM issues i LEFT JOIN issue_assignees ia ON i.id = ia.issue_id WHERE i.state_id = 1 AND ia.user_id IS NULL")
 unassigned = cursor.fetchone()[0]
 cursor.close()
 
 cursor = db.cursor()
-cursor.execute("SELECT COUNT(*) FROM issues i LEFT JOIN issue_assignees ia ON i.id = ia.issue_id WHERE i.state IN ('opened', 'reopened') AND ia.user_id IS NOT NULL")
+cursor.execute("SELECT COUNT(*) FROM issues i LEFT JOIN issue_assignees ia ON i.id = ia.issue_id WHERE i.state_id = 1 AND ia.user_id IS NOT NULL")
 assigned = cursor.fetchone()[0]
 cursor.close()
 

--- a/gitlab_total_issues_throughput
+++ b/gitlab_total_issues_throughput
@@ -28,7 +28,7 @@ count_opened = cursor.fetchone()[0]
 cursor.close()
 
 cursor = db.cursor()
-cursor.execute("SELECT COUNT(*) FROM issues WHERE state = 'closed'")
+cursor.execute("SELECT COUNT(*) FROM issues WHERE state_id = 2")
 count_closed = cursor.fetchone()[0]
 cursor.close
 

--- a/gitlab_total_merge_requests_open
+++ b/gitlab_total_merge_requests_open
@@ -16,7 +16,7 @@ if len(sys.argv) >= 2 and sys.argv[1] == 'config':
 gitlab = get_gitlab_instance()
 db = gitlab.get_db_connection()
 cursor = db.cursor()
-cursor.execute("SELECT COUNT(*) FROM merge_requests WHERE state IN ('opened', 'reopened', 'locked')")
+cursor.execute("SELECT COUNT(*) FROM merge_requests WHERE state_id = 1")
 count = cursor.fetchone()[0]
 cursor.close()
 db.close()

--- a/gitlab_total_merge_requests_throughput
+++ b/gitlab_total_merge_requests_throughput
@@ -28,7 +28,7 @@ count_opened = cursor.fetchone()[0]
 cursor.close()
 
 cursor = db.cursor()
-cursor.execute("SELECT COUNT(*) FROM merge_requests WHERE state = 'merged'")
+cursor.execute("SELECT COUNT(*) FROM merge_requests WHERE state_id = 3")
 count_merged = cursor.fetchone()[0]
 cursor.close
 


### PR DESCRIPTION
Adapted the issues and merge_requests plugins to new state_id column.