### PR TITLE
Fix SQL syntax error for postgres in  gitlab_users_active 

### DIFF
--- a/gitlab_users_active
+++ b/gitlab_users_active
@@ -28,7 +28,7 @@ else:
             cursor.execute(
                 "SELECT COUNT(last_sign_in_at) "
                 "FROM users "
-                "WHERE last_sign_in_at > CURRENT_TIMESTAMP - INTERVAL %s day ",
+                "WHERE last_sign_in_at > CURRENT_TIMESTAMP - INTERVAL '%s day' ",
                 (day,)
             )
             days.update({day: cursor.fetchone()[0]})


### PR DESCRIPTION
Solves #32.

Error was 
```
Error output from gitlab_users_active:
2018/11/15-13:00:25 [2769]      Traceback (most recent call last):
2018/11/15-13:00:25 [2769]        File "/etc/munin/plugins/gitlab_users_active", line 32, in <module>
2018/11/15-13:00:25 [2769]          (day,)
2018/11/15-13:00:25 [2769]      psycopg2.ProgrammingError: syntax error at or near "1"
2018/11/15-13:00:25 [2769]      LINE 1: ... WHERE last_sign_in_at > CURRENT_TIMESTAMP - INTERVAL 1 day 
```
Does not work for MySQL anymore, but support for MySQL was deprecated in `12.1` anyway (https://about.gitlab.com/blog/2019/06/27/removing-mysql-support/). So should be fine.