### PR TITLE
add warning for status 'failed'

### DIFF
--- a/gitlab_remote_mirrors
+++ b/gitlab_remote_mirrors
@@ -15,12 +15,24 @@ if SHOW_CONFIG:
     print('graph_category gitlab')
 
 cursor = db.cursor()
-cursor.execute(
-    "SELECT n.path, p.path, rm.update_status, COUNT(rm.id) as count "
-    "FROM remote_mirrors rm, projects p, namespaces n "
-    "WHERE p.id = rm.project_id AND n.id = p.namespace_id AND p.archived=false "
-    "GROUP BY n.path, p.path, rm.update_status "
-    "ORDER BY n.path, p.path, rm.update_status ASC")
+cursor.execute("SELECT n.path, p.path, rm.update_status, COUNT(rm.id) FILTER( WHERE rm.id != 0) FROM "
+               "("
+               # All current status lines for mirrors
+               "    SELECT rm_expected.update_status, rm_expected.project_id,rm_expected.id FROM remote_mirrors rm_expected"
+               "    UNION ALL"
+               # All known missing status codes for projects that have mirrors
+               "    SELECT s.status as update_status, p.id as project_id, 0 as id FROM"
+               "        (VALUES ('finished'), ('to_retry'), ('failed')) AS s(status), projects p"
+               "    WHERE"
+               #          All projects that have mirrors 
+               "          EXISTS (SELECT FROM remote_mirrors rm_exist WHERE rm_exist.project_id = p.id) "
+               #          And don't have a mirror in this status
+               "          AND NOT EXISTS (SELECT FROM remote_mirrors rm_exist_status WHERE rm_exist_status.project_id = p.id AND rm_exist_status.update_status = s.status)"
+               ") AS rm, projects p, namespaces n "
+               "WHERE p.id = rm.project_id AND n.id = p.namespace_id "
+               "GROUP BY n.path, p.path, rm.update_status "
+               "ORDER BY n.path, p.path, rm.update_status ASC")
+
 
 def print_row(row):
     group = munin_safe_id(row[0])
@@ -29,7 +41,7 @@ def print_row(row):
     count = row[3]
     if SHOW_CONFIG:
         print('{0}_{1}_{2}.label {3}/{4} {5}'.format(group, project, update_status, row[0], row[1], row[2]))
-        if update_status in ['to_retry']:
+        if update_status in ['to_retry', 'failed']:
             print('{0}_{1}_{2}.warning 0:0'.format(group, project, update_status))
             print('{0}_{1}_{2}.draw LINESTACK1'.format(group, project, update_status))
         elif update_status in ['finished']:
@@ -38,51 +50,10 @@ def print_row(row):
     else:
         print('{0}_{1}_{2}.value {3:d}'.format(group, project, update_status, count))
 
-def same_project(row1, row2):
-    return len(row1) > 1 and len(row2) > 1 and row1[0] == row2[0] and row1[1] == row2[1]
 
-def copy_row(row, overwrite_colums={}):
-    return tuple(
-        overwrite_columns[i] if i in overwrite_columns else
-        'to_retry' if i == 2 else
-        last_row[i]
-        for i in range(0,len(last_row))
-    )
-
-
-last_row = ()
 for row in cursor.fetchall():
-    if last_row and not same_project(row, last_row):
-        if last_row[2] != 'to_retry':
-        # print to_retry row even if there is no to_retry mirror for this project
-            to_retry_row = tuple(
-                0 if i == 3 else 
-                'to_retry' if i == 2 else
-                last_row[i]
-                for i in range(0,len(last_row))
-            )
-            print_row(to_retry_row)
-    if row[2] == last_row[2] == 'to_retry':
-            # print finshed row event if there is not finished mirror for this project
-            finished_row = tuple(
-                0 if i == 3 else
-                'finished' if i == 2 else
-                row[i]
-                for i in range(0,len(row))
-            )
-            print_row(finished_row)
     print_row(row)
-    last_row = row
 
-if last_row and last_row[2] == 'finished':
-    # print to_retry row even if there is no to_retry mirror for this project
-    to_retry_row = tuple(
-        0 if i == 3 else
-        'to_retry' if i == 2 else
-        last_row[i]
-        for i in range(0,len(last_row))
-    )
-    print_row(to_retry_row)
 
 cursor.close()
 db.close()


### PR DESCRIPTION
also move missing status line aggregation to sql

implemented this becuase our gitlab instance suddenly showed a new status 'failed' for remote mirrors (when pushing an already existing tag)

Info @wt-io-it