### PR TITLE
fix gitlab_total_repo_* for hashed repo storage

### DIFF
--- a/gitlab_total_repo_count
+++ b/gitlab_total_repo_count
@@ -3,10 +3,10 @@
 from lib import get_gitlab_instance
 import os
 import sys
+import glob
 
 gitlab = get_gitlab_instance()
 repository_root = gitlab.get_repository_dir()
-
 if len(sys.argv) >= 2 and sys.argv[1] == 'config':
     print('graph_title GitLab Repository Count')
     print('graph_vlabel Repository Count')
@@ -26,11 +26,16 @@ wiki_empty_count = 0
 
 try:
     namespaces = os.listdir(repository_root)
+    if '@hashed' in namespaces:
+	repository_root = os.path.join(repository_root, '@hashed')
+        namespaces = os.listdir(repository_root)
     for namespace in namespaces:
-        subdir = repository_root + os.sep + namespace
+        subdir = os.path.join(repository_root, namespace)
         if os.path.isfile(subdir):
             continue
-        repos = os.listdir(subdir)
+        repos = glob.glob(os.path.join(subdir, '*', '*.git'))
+	if not repos:
+            repos = os.listdir(subdir)
         for repo in repos:
             if repo.endswith('.wiki.git'):
                 try:

--- a/gitlab_total_repo_size
+++ b/gitlab_total_repo_size
@@ -4,6 +4,7 @@ from lib import dirsize
 from lib import get_gitlab_instance
 import os
 import sys
+import glob
 
 gitlab = get_gitlab_instance()
 repository_root = gitlab.get_repository_dir()
@@ -24,13 +25,18 @@ wiki_size = 0
 
 try:
     namespaces = os.listdir(repository_root)
+    if '@hashed' in namespaces:
+        repository_root = os.path.join(repository_root, '@hashed')
+	namespaces = os.listdir(repository_root)
     for namespace in namespaces:
-        subdir = repository_root + os.sep + namespace
+        subdir = os.path.join(repository_root, namespace)
         if os.path.isfile(subdir):
             continue
-        repos = os.listdir(subdir)
+	repos = glob.glob(os.path.join(subdir, '*', '*.git'))
+	if not repos:
+            repos = os.listdir(subdir)
         for repo in repos:
-            repo_path = subdir + os.sep + repo
+            repo_path = os.path.join(subdir, repo)
             if repo.endswith('.wiki.git'):
                 wiki_size += dirsize(repo_path)
             elif repo.endswith('.git'):


### PR DESCRIPTION
see https://docs.gitlab.com/ee/administration/repository_storage_types.html#hashed-storage
hashed storage became default in 12.0, legacy storage was deprecated in
 13.0 and removed in 14.0
 
Info @wt-io-it