### PR TITLE
TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/lib/gitlab.py
+++ b/lib/gitlab.py
@@ -68,8 +68,9 @@ class GitLabInstance(object):
         redis = self.get_redis_connection()
         if redis is None:
             raise GitLabError('Redis connection not available')
-        redis.send('INFO\r\n')
-        data = redis.recv(16384)
+        data = 'INFO\r\n'
+        redis.send(data.encode('ascii'))
+        data = redis.recv(16384).decode('ascii')
         redis.close()
         info = {}
         for line in data.split('\n'):
@@ -88,8 +89,9 @@ class GitLabInstance(object):
         redis = self.get_redis_connection()
         if redis is None:
             raise GitLabError('Redis connection not available')
-        redis.send('*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$' + str(len(param)) + '\r\n' + param + '\r\n')
-        data = redis.recv(16384)
+        data = '*3\r\n$6\r\nCONFIG\r\n$3\r\nGET\r\n$' + str(len(param)) + '\r\n' + param + '\r\n'
+        redis.send(data.encode('ascii'))
+        data = redis.recv(16384).decode('ascii')
         redis.close()
         values = []
         for line in data.split('\n'):


### PR DESCRIPTION
python socket send and recv do not work with strings. Bytes are needed instead.

According to the [Redis Protocol Spec](https://redis.io/docs/latest/develop/reference/protocol-spec/), the encoding is in "ascii". 

Adding the conversion of the data sending to redis and receiving from redis.

Solves issue #45 