### PR TITLE
Update after database table change

### DIFF
--- a/gitlab_ci_builds
+++ b/gitlab_ci_builds
@@ -26,6 +26,6 @@ gitlab = get_gitlab_instance()
 db = gitlab.get_db_connection()
 for state in ('success', 'failed', 'canceled'):
     cursor = db.cursor()
-    cursor.execute("SELECT COUNT(*) FROM ci_builds WHERE status = '{state}'".format(state=state))
+    cursor.execute("SELECT COUNT(*) FROM p_ci_builds WHERE status = '{state}'".format(state=state))
     print('{state}.value {value}'.format(state=state, value=cursor.fetchone()[0]))
 

--- a/gitlab_ci_builds_current
+++ b/gitlab_ci_builds_current
@@ -23,6 +23,6 @@ gitlab = get_gitlab_instance()
 db = gitlab.get_db_connection()
 for state in ('created', 'pending', 'running'):
     cursor = db.cursor()
-    cursor.execute("SELECT COUNT(*) FROM ci_builds WHERE status = '{state}'".format(state=state))
+    cursor.execute("SELECT COUNT(*) FROM p_ci_builds WHERE status = '{state}'".format(state=state))
     print('{state}.value {value}'.format(state=state, value=cursor.fetchone()[0]))
 


### PR DESCRIPTION
A while ago the ci_builds table in Gitlab database was restructured. Seem the new table name is p_ci_builds.

https://gitlab.com/gitlab-org/gitlab/-/work_items/30441

This closes issue #47 